### PR TITLE
Added ability to join chapters with spaces

### DIFF
--- a/COGS/info.py
+++ b/COGS/info.py
@@ -216,6 +216,15 @@ class Info(commands.Cog, description="Info :scroll:"):
             if group.lower() in g.lower():
                 group, match = g, True
                 break
+
+        # Error Correction for e.g.: "-chapter computer chapter"
+        if leader:
+            ec = leader.split()
+            print(ec)
+            if ec[0] in group.lower():
+                leader = leader[len(ec[0]):].strip()
+                print(f"{leader=}")
+
         # End command if no filtered result
         if not match:
             return await ctx.reply(f"\"{group}\" is not a \"{branch}\"")


### PR DESCRIPTION
Argument leader takes in multiple words, whereas group does not.  So if chapter/committee is in the variable leader, then that string will be ignored. This avoids the logic error where the bot thinks it is looking for a leader named e.g. chapter chair, when it should be only looking for a leader named chair.