### PR TITLE
Revision v1.3

### DIFF
--- a/COGS/info.py
+++ b/COGS/info.py
@@ -220,10 +220,8 @@ class Info(commands.Cog, description="Info :scroll:"):
         # Error Correction for e.g.: "-chapter computer chapter"
         if leader:
             ec = leader.split()
-            print(ec)
             if ec[0] in group.lower():
                 leader = leader[len(ec[0]):].strip()
-                print(f"{leader=}")
 
         # End command if no filtered result
         if not match:

--- a/COGS/utils.py
+++ b/COGS/utils.py
@@ -294,6 +294,13 @@ class Utilities(commands.Cog, description="Utilities :tools:"):
                     if group.lower() in g.lower():
                         group, match = g, True
                         break
+
+                # Error Correction for e.g.: "-chapter computer chapter"
+                if leader:
+                    ec = leader.split()
+                    if ec[0] in group.lower():
+                        leader = leader[len(ec[0]):].strip()
+
                 if not match:
                     return await ctx.reply(f"\"{group}\" is not a recognisable option in \"{cat}\"")
                 elif leader:


### PR DESCRIPTION
e.g. -edit chapter computer chapter
Now works as intended and "chapter/committee" is not a recognisable option in "Chapters > Computer Chapter " is no longer replied. This is done by checking if there is "chapter/committee" in the leader argument. If there is, then those characters are deleted. 